### PR TITLE
Improve release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,9 +64,7 @@
     "typescript": "3.7.2"
   },
   "scripts": {
-    "authors": "node dist/cli authors > AUTHORS",
     "build": "run-s clean compile",
-    "changelog": "node dist/cli changelog -f v$npm_package_version > CHANGELOG.md",
     "check:format": "prettier --list-different \"**/*.{js,ts}\"",
     "check:types": "tsc --noEmit",
     "clean": "run-p clean:*",
@@ -79,7 +77,6 @@
     "release": "node dist/cli release",
     "test": "run-s check:* lint build test:*",
     "test:cjs": "jest --config ./scripts/jest/config.cjs.js",
-    "test:src": "jest --config ./scripts/jest/config.src.js",
-    "version": "run-s test changelog authors && git add ."
+    "test:src": "jest --config ./scripts/jest/config.src.js"
   }
 }

--- a/scripts/jest/config.cjs.js
+++ b/scripts/jest/config.cjs.js
@@ -5,6 +5,8 @@ module.exports = Object.assign({}, srcConfig, {
   moduleNameMapper: {
     '^../src$': '<rootDir>/dist/index.js',
     '^../src/data$': '<rootDir>/dist/data.js',
-    '^../src/otp$': '<rootDir>/dist/otp.js'
+    '^../src/otp$': '<rootDir>/dist/otp.js',
+    '^../src/changelog$': '<rootDir>/dist/changelog.js',
+    '^../src/authors$': '<rootDir>/dist/authors.js'
   }
 });

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -1,10 +1,26 @@
+/* eslint-disable @typescript-eslint/camelcase */
+
 jest.mock('execa');
+jest.mock('fs', () => ({
+  promises: {
+    writeFile: jest.fn()
+  }
+}));
+jest.mock('../src/changelog');
+jest.mock('../src/authors');
 jest.mock('../src/otp', () => ({
   prompt: async () => '123'
 }));
 
 import execa from 'execa';
 import { release } from '../src';
+import changelog from '../src/changelog';
+
+const originalNpmPackageVersion = process.env.npm_package_version;
+
+afterEach(() => {
+  process.env.npm_package_version = originalNpmPackageVersion;
+});
 
 test('throws if any PRs are unlabelled', async () => {
   await expect(release()).rejects.toThrow();
@@ -21,23 +37,22 @@ test('handles no tags', async () => {
       res.status(200).json([]);
     });
 
+  // Mimic the major version bump from `npm version major`.
+  process.env.npm_package_version = '5.0.0';
+
   await release();
 
-  expect(execa).toHaveBeenCalledTimes(4);
   expect(execa).toHaveBeenNthCalledWith(
     1,
     'npm',
     ['version', 'major', '-m', 'Release v%s'],
     { stdio: 'inherit' }
   );
-  expect(execa).toHaveBeenNthCalledWith(2, 'git', ['push'], {
-    stdio: 'inherit'
+  expect(changelog).toHaveBeenCalledTimes(1);
+  expect(changelog).toHaveBeenCalledWith({
+    futureRelease: `v${process.env.npm_package_version}`
   });
-  expect(execa).toHaveBeenNthCalledWith(3, 'git', ['push', '--tags'], {
-    stdio: 'inherit'
-  });
-  expect(execa).toHaveBeenNthCalledWith(
-    4,
+  expect(execa).toHaveBeenCalledWith(
     'npm',
     ['publish', '--access', 'public', '--otp', '123'],
     {
@@ -47,23 +62,22 @@ test('handles no tags', async () => {
 });
 
 test('runs a major release', async () => {
+  // Mimic the major version bump from `npm version major`.
+  process.env.npm_package_version = '5.0.0';
+
   await release();
 
-  expect(execa).toHaveBeenCalledTimes(4);
   expect(execa).toHaveBeenNthCalledWith(
     1,
     'npm',
     ['version', 'major', '-m', 'Release v%s'],
     { stdio: 'inherit' }
   );
-  expect(execa).toHaveBeenNthCalledWith(2, 'git', ['push'], {
-    stdio: 'inherit'
+  expect(changelog).toHaveBeenCalledTimes(1);
+  expect(changelog).toHaveBeenCalledWith({
+    futureRelease: `v${process.env.npm_package_version}`
   });
-  expect(execa).toHaveBeenNthCalledWith(3, 'git', ['push', '--tags'], {
-    stdio: 'inherit'
-  });
-  expect(execa).toHaveBeenNthCalledWith(
-    4,
+  expect(execa).toHaveBeenCalledWith(
     'npm',
     ['publish', '--access', 'public', '--otp', '123'],
     {
@@ -73,23 +87,22 @@ test('runs a major release', async () => {
 });
 
 test('runs a minor release', async () => {
+  // Mimic the minor version bump from `npm version minor`.
+  process.env.npm_package_version = '4.1.0';
+
   await release();
 
-  expect(execa).toHaveBeenCalledTimes(4);
   expect(execa).toHaveBeenNthCalledWith(
     1,
     'npm',
     ['version', 'minor', '-m', 'Release v%s'],
     { stdio: 'inherit' }
   );
-  expect(execa).toHaveBeenNthCalledWith(2, 'git', ['push'], {
-    stdio: 'inherit'
+  expect(changelog).toHaveBeenCalledTimes(1);
+  expect(changelog).toHaveBeenCalledWith({
+    futureRelease: `v${process.env.npm_package_version}`
   });
-  expect(execa).toHaveBeenNthCalledWith(3, 'git', ['push', '--tags'], {
-    stdio: 'inherit'
-  });
-  expect(execa).toHaveBeenNthCalledWith(
-    4,
+  expect(execa).toHaveBeenCalledWith(
     'npm',
     ['publish', '--access', 'public', '--otp', '123'],
     {
@@ -99,23 +112,22 @@ test('runs a minor release', async () => {
 });
 
 test('runs a patch release', async () => {
+  // Mimic the patch version bump from `npm version patch`.
+  process.env.npm_package_version = '4.0.7';
+
   await release();
 
-  expect(execa).toHaveBeenCalledTimes(4);
   expect(execa).toHaveBeenNthCalledWith(
     1,
     'npm',
     ['version', 'patch', '-m', 'Release v%s'],
     { stdio: 'inherit' }
   );
-  expect(execa).toHaveBeenNthCalledWith(2, 'git', ['push'], {
-    stdio: 'inherit'
+  expect(changelog).toHaveBeenCalledTimes(1);
+  expect(changelog).toHaveBeenCalledWith({
+    futureRelease: `v${process.env.npm_package_version}`
   });
-  expect(execa).toHaveBeenNthCalledWith(3, 'git', ['push', '--tags'], {
-    stdio: 'inherit'
-  });
-  expect(execa).toHaveBeenNthCalledWith(
-    4,
+  expect(execa).toHaveBeenCalledWith(
     'npm',
     ['publish', '--access', 'public', '--otp', '123'],
     {


### PR DESCRIPTION
Moves changelog and authors generation into the release script. This takes advantage of data caching and simplified the npm scripts setup.