### PR TITLE
fix: upgrade minimatch to resolve ReDoS vulnerability

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Copilot Instructions
+
+## Verification
+
+After making changes to dependencies or source code, always verify by running the relevant npm scripts before committing:
+
+- `npm run check:types` — type checking
+- `npm run lint` — linting
+- `npm run build` — clean build
+- `npm run test:src` — source tests
+- `npm run test:cjs` — compiled output tests
+
+Note: The CLI integration tests in `test/cli.test.ts` make real GitHub API calls and require `CHANGELOG_GITHUB_TOKEN` to be set. They are expected to take 2-3 minutes. For quick verification, running just the release tests (`--testPathPatterns release.test`) is sufficient.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "tanem-scripts",
-      "version": "8.0.5",
+      "version": "8.0.6",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^22.0.1",
@@ -662,9 +662,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4852,13 +4852,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6183,9 +6183,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Summary

Resolves all 3 open Dependabot alerts for **minimatch ReDoS vulnerabilities** (GHSA-7r86-cg39-jmmj, High severity).

## Changes

- Ran `npm audit fix` to upgrade minimatch across the dependency tree
- Added `.github/copilot-instructions.md` with verification steps for future changes

## Verification

- ✅ `npm run check:types` — passes
- ✅ `npm run lint` — passes
- ✅ `npm run build` — passes
- ✅ `npm run test:src` — passes (both release and CLI integration tests)
- ✅ `npm run test:cjs` — passes
- ✅ `npm audit` — 0 vulnerabilities