### PR TITLE
fix: exit 0 when there is nothing to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import { changelog } from 'tanem-scripts';
 
 ### release()
 
-Returns a `Promise` that will be resolved once the release script completes. If an error occurs during execution, the `Promise` is rejected with an `Error` object.
+Returns a `Promise` that resolves with `'released'` once the release script completes, or `'nothing-to-release'` if no pull requests have merged since the last published tag. If an error occurs during execution, the `Promise` is rejected with an `Error` object.
 
 **Example**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,10 @@ program
   .description('publishes a package to npm')
   .action(async () => {
     try {
-      await release();
+      const result = await release();
+      if (result === 'nothing-to-release') {
+        process.stdout.write('Nothing to release\n');
+      }
     } catch (error) {
       console.error(error);
       process.exit(1);

--- a/src/release.ts
+++ b/src/release.ts
@@ -12,7 +12,7 @@ import { get as getData } from './data';
 
 const execaOptions: execa.Options = { stdio: 'inherit' };
 
-const release = async (): Promise<void> => {
+const release = async (): Promise<'released' | 'nothing-to-release'> => {
   const { pulls, tags } = await getData();
 
   const latestTag = tags[tags.length - 1];
@@ -24,7 +24,7 @@ const release = async (): Promise<void> => {
     : pulls;
 
   if (pullsToRelease.length === 0) {
-    throw new Error('Nothing to release');
+    return 'nothing-to-release';
   }
 
   const labelsToRelease = [
@@ -101,6 +101,8 @@ const release = async (): Promise<void> => {
     ['publish', '--provenance', '--access', 'public'],
     execaOptions,
   );
+
+  return 'released';
 };
 
 export default release;

--- a/test/release.test.ts
+++ b/test/release.test.ts
@@ -75,7 +75,7 @@ describe('release validation', () => {
     );
   });
 
-  test('throws if nothing to release', async () => {
+  test("returns 'nothing-to-release' if there is nothing to release", async () => {
     const mockDataNoNewPulls = {
       ...mockDataWithLabels,
       tags: [
@@ -88,6 +88,6 @@ describe('release validation', () => {
     jest
       .spyOn(data, 'get')
       .mockResolvedValue(mockDataNoNewPulls as unknown as data.Data);
-    await expect(release()).rejects.toThrow('Nothing to release');
+    await expect(release()).resolves.toBe('nothing-to-release');
   });
 });


### PR DESCRIPTION
## Summary
- The scheduled weekly `Release` workflow was failing (red X, notification noise) whenever no PRs had merged since the last tag - `release()` threw `Error('Nothing to release')`, which `cli.ts` treated the same as any other command failure (`console.error` + `process.exit(1)`).
- `release()` now resolves `'nothing-to-release'` in that case instead of throwing; `cli.ts` prints `Nothing to release` and exits 0. Genuine validation errors (unlabelled PRs, PRs with multiple labels) are unchanged and still exit 1.

## Test plan
- [x] `npm run check:types`, `npm run lint`, `npm run check:format` all pass
- [x] `npm run build` succeeds
- [x] `npm run test:src` and `npm run test:cjs` both pass all 3 `release` unit tests (source and compiled `dist` behave identically)
- [x] Confirmed the 3 unrelated `cli.test.ts` failures (authors/changelog integration tests needing a live `CHANGELOG_GITHUB_TOKEN`) are pre-existing on `master`, not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)